### PR TITLE
質問で必須を選択可能に

### DIFF
--- a/src/components/QuestionsEdit/QuestionEditor.vue
+++ b/src/components/QuestionsEdit/QuestionEditor.vue
@@ -101,6 +101,14 @@ const handleTypeChange = () => {
       />
       <div class="d-flex ga-2">
         <v-checkbox
+          v-model="question.isRequired"
+          label="必須"
+          color="primary"
+          density="compact"
+          :disabled="isAssignedId(question.id)"
+          hide-details
+        />
+        <v-checkbox
           v-model="question.isPublic"
           label="回答を公開"
           color="primary"

--- a/src/components/QuestionsEdit/QuestionEditor.vue
+++ b/src/components/QuestionsEdit/QuestionEditor.vue
@@ -105,7 +105,6 @@ const handleTypeChange = () => {
           label="必須"
           color="primary"
           density="compact"
-          :disabled="isAssignedId(question.id)"
           hide-details
         />
         <v-checkbox


### PR DESCRIPTION
close #46 
合宿参加登録前にあたり暫定的に作成

`QuestionEditor.vue`にチェックボックスを追加し、作成時に「必須」を選択できるようにした
~~編集時は「必須」を変更できない~~
→変更できるようにした

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 質問編集画面に「必須」チェックボックスを追加しました。
  * 質問への回答を必須に設定できるようになりました。
  * 既に割り当て済みの質問では、設定を変更できない場合があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->